### PR TITLE
refactor(pipeline): fix dummy finder output loading and clean up find…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ cmd-line-exploit.txt
 # exploiter specific
 Agents/Exploiter/logs/*
 
+#Claude 
+.claude/
+
 # Projects
 Projects/Sources/*
 Projects/Zipped/*

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -672,6 +672,13 @@ def _exploiter_node(state: AutoSecState) -> Command:
 def _patcher_node(state: AutoSecState) -> AutoSecState:
     logger.info("Node - patcher started")
 
+    # Skip if dummy patcher data was injected via --use-dummy patcher.
+    # The "dummy" flag is set in _build_initial_state.
+    existing_patcher = state.get("patcher") or {}
+    if existing_patcher.get("dummy"):
+        logger.info("Node - patcher skipped (dummy data injected)")
+        return state
+
     if not state.get("language"):
         raise ValueError("language missing from state")
 

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -102,7 +102,8 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Reuse the existing project source tree (skip re-extraction from zip) "
             "and bypass any cached/dummy Finder output, forcing IRIS to recompute. "
-            "Defaults to false (re-extract source from zip on each run)."
+            "Defaults to false: reuse any injected/cached Finder output if present "
+            "(see --use-dummy); otherwise extract source from zip and run IRIS."
         ),
     )
 

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -293,13 +294,6 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
 
     query = vuln_id + "wLLM"
 
-    build_and_analyze_args = (
-        f"--project-name {project_name} "
-        f"--query {query} "
-        f"--model {model} "
-        f"--overwrite "
-    )
-
     # finder_reanalyze=True keeps the existing source tree (e.g. Exploiter retry
     # where the project is already extracted). Default re-extracts from the zip.
     # Fallback: if the source tree isn't actually on disk (e.g. dummy was used
@@ -309,15 +303,33 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
     project_source_dir = PROJECTS_DIR / "Sources" / project_name
     keep_source = state.get("finder_reanalyze", False) and project_source_dir.exists()
 
+    build_and_analyze_argv = [
+        "python3", "./scripts/build_and_analyze.py",
+        "--project-name", project_name,
+        "--query", query,
+        "--model", model,
+        "--overwrite",
+    ]
+
     if not keep_source:
         if state.get("finder_reanalyze") and not project_source_dir.exists():
             logger.info(
                 f"finder_reanalyze=True but source tree missing at "
                 f"{project_source_dir}; forcing re-extraction from zip."
             )
-        build_and_analyze_args += f"--zip-path /workspace/Projects/Zipped/{project_name}.zip"
+        build_and_analyze_argv += [
+            "--zip-path", f"/workspace/Projects/Zipped/{project_name}.zip",
+        ]
 
-    print(f"\n---- ARGS: {build_and_analyze_args} ----\n")
+    # Shell-quote the python invocation since we have to route through bash -lc
+    # to source conda. shlex.join protects against spaces / metacharacters in
+    # user-supplied values like --finder-model.
+    inner_cmd = (
+        "source /opt/conda/etc/profile.d/conda.sh && conda activate iris && "
+        + shlex.join(build_and_analyze_argv)
+    )
+
+    print(f"\n---- ARGS: {shlex.join(build_and_analyze_argv[2:])} ----\n")
 
     if model.startswith("gpt"):
         os.getenv("OPEN_AI_KEY")
@@ -342,8 +354,7 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
         "iris:latest",
         "bash",
         "-lc",
-        "source /opt/conda/etc/profile.d/conda.sh && conda activate iris && "
-        "python3 ./scripts/build_and_analyze.py " + build_and_analyze_args,
+        inner_cmd,
     ]
 
     logger.info(f"Running IRIS inside Docker for project {project_name}")

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -99,19 +99,23 @@ def _parse_args() -> argparse.Namespace:
         "--finder-reanalyze",
         action="store_true",
         default=False,
-        help="Force Finder reanalysis using --overwrite. Defaults to false.",
+        help=(
+            "Reuse the existing project source tree (skip re-extraction from zip) "
+            "and bypass any cached/dummy Finder output, forcing IRIS to recompute. "
+            "Defaults to false (re-extract source from zip on each run)."
+        ),
     )
 
     parser.add_argument(
         "--use-dummy",
+        action="extend",
         nargs="*",
         choices=["finder", "exploiter", "patcher"],
-        default=[],
+        default=["finder"],
         help=(
-            "Inject dummy state before running. "
-            "Examples: --use-dummy finder, "
-            "--use-dummy finder exploiter, "
-            "--use-dummy patcher"
+            "Add to the default dummy set [finder]. "
+            "Examples: '--use-dummy patcher' -> [finder, patcher]; "
+            "'--use-dummy finder exploiter' -> [finder, exploiter]."
         ),
     )
 
@@ -257,7 +261,8 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
     logger.info("Node - finder started")
 
     # Skip finder if output was already injected, e.g. dummy/cached output.
-    if state.get("finder_output") is not None:
+    # finder_reanalyze=True overrides the cache to force a real run.
+    if state.get("finder_output") is not None and not state.get("finder_reanalyze"):
         logger.info("Node - finder skipped because finder_output is already set")
         return state
 
@@ -288,11 +293,24 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
         f"--project-name {project_name} "
         f"--query {query} "
         f"--model {model} "
+        f"--overwrite "
     )
 
-    if state.get("finder_reanalyze", False):
-        build_and_analyze_args += "--overwrite"
-    else:
+    # finder_reanalyze=True keeps the existing source tree (e.g. Exploiter retry
+    # where the project is already extracted). Default re-extracts from the zip.
+    # Fallback: if the source tree isn't actually on disk (e.g. dummy was used
+    # on the first pass so IRIS never extracted), force re-extraction even when
+    # finder_reanalyze=True — otherwise IRIS's Maven build would have nothing
+    # to compile against.
+    project_source_dir = PROJECTS_DIR / "Sources" / project_name
+    keep_source = state.get("finder_reanalyze", False) and project_source_dir.exists()
+
+    if not keep_source:
+        if state.get("finder_reanalyze") and not project_source_dir.exists():
+            logger.info(
+                f"finder_reanalyze=True but source tree missing at "
+                f"{project_source_dir}; forcing re-extraction from zip."
+            )
         build_and_analyze_args += f"--zip-path /workspace/Projects/Zipped/{project_name}.zip"
 
     print(f"\n---- ARGS: {build_and_analyze_args} ----\n")

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -385,6 +385,13 @@ def _finder_node(state: AutoSecState) -> AutoSecState:
 def _exploiter_node(state: AutoSecState) -> Command:
     logger.info("Node: exploiter started")
 
+    # Skip if dummy exploiter data was injected via --use-dummy exploiter.
+    # The "dummy" flag is set in _build_initial_state.
+    existing_exploiter = state.get("exploiter") or {}
+    if existing_exploiter.get("dummy"):
+        logger.info("Node: exploiter skipped (dummy data injected)")
+        return Command(goto=_route_after_exploiter(state), update=state)
+
     running_finder = True
 
     new_state: AutoSecState = dict(state)

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -101,8 +101,10 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         help=(
-            "Reuse the existing project source tree (skip re-extraction from zip) "
-            "and bypass any cached/dummy Finder output, forcing IRIS to recompute. "
+            "Reuse the existing project source tree under Projects/Sources/<project> "
+            "to skip re-extracting from zip, and bypass any cached/dummy Finder output, "
+            "forcing IRIS to recompute. If the source tree is missing on disk, IRIS falls "
+            "back to re-extracting from the zip so the Maven build has something to compile. "
             "Defaults to false: reuse any injected/cached Finder output if present "
             "(see --use-dummy); otherwise extract source from zip and run IRIS."
         ),

--- a/Pipeline/pipeline.py
+++ b/Pipeline/pipeline.py
@@ -113,9 +113,12 @@ def _parse_args() -> argparse.Namespace:
         choices=["finder", "exploiter", "patcher"],
         default=["finder"],
         help=(
-            "Add to the default dummy set [finder]. "
-            "Examples: '--use-dummy patcher' -> [finder, patcher]; "
-            "'--use-dummy finder exploiter' -> [finder, exploiter]."
+            "Skip the listed agents and populate their state from "
+            "pre-existing dummy data. Added on top of the default set "
+            "[finder]. "
+            "Examples: '--use-dummy patcher' -> skip [finder, patcher]; "
+            "'--use-dummy finder exploiter patcher' -> skip all three, "
+            "leaving only Verifier to run in --mode all."
         ),
     )
 

--- a/Pipeline/scripts/convert_to_finder_output.py
+++ b/Pipeline/scripts/convert_to_finder_output.py
@@ -15,9 +15,12 @@ def main():
 
     parser.add_argument("project_name", help="Project folder name under Agents/Finder/output")
     parser.add_argument("cwe_id", help="CWE id like cwe-022")
-    parser.add_argument("output_json", help="Output JSON filename")
+    parser.add_argument("output_json", help="Output JSON filename (.json appended if omitted)")
 
     args = parser.parse_args()
+
+    if not args.output_json.endswith(".json"):
+        args.output_json += ".json"
 
     project_name = args.project_name
     cwe_id = args.cwe_id

--- a/Pipeline/utils.py
+++ b/Pipeline/utils.py
@@ -1,26 +1,11 @@
 # Pipeline/utils.py
 import json
-from typing import TypedDict, List, Any, Dict, Optional
+from typing import Any, Dict, Optional
 from pathlib import Path
 from datetime import datetime, timezone
-
+from Agents.Finder.src.types import FinderOutput
 from Pipeline.project_variants import ProjectVariants
 
-
-# TypedDict Definitions
-class TraceStep(TypedDict, total=False):
-    uri: str
-    line: int
-    message: str
-
-Trace = List[TraceStep]
-
-class VulnerabilityInstance(TypedDict):
-    traces: List[Trace]
-
-class FinderOutput(TypedDict):
-    cwe_id: str
-    vulnerabilities: List[VulnerabilityInstance]
 
 #* =============== Exploiter Utilities =============== *#
 def has_actionable_vulnerabilities(finder_output: Optional[Dict[str, Any]]) -> bool:

--- a/Pipeline/utils.py
+++ b/Pipeline/utils.py
@@ -82,13 +82,17 @@ def parse_exploiter_report(report_data) -> tuple[bool, list[str], str]:
 
 #* =============== Dummy Data Loaders & Validators =============== *#
 # Loader + Validator
-def load_dummy_finder_output(json_path: str) -> FinderOutput:
+def load_dummy_finder_output(json_path: str) -> Optional[FinderOutput]:
     """
     Load a JSON file and validate that it matches the expected FinderOutput schema.
-    
-    Raises:
-        ValueError if structure is invalid.
+
+    Returns None if the file does not exist, so the Finder node can run normally.
+    Raises ValueError if the file exists but its structure is invalid.
     """
+    if not Path(json_path).exists():
+        print(f"====== No injected Finder output at {json_path} — Finder will run ======")
+        return None
+    
     print(f"====== Loading Injected Finder output from: {json_path} ======")
 
     with open(json_path, "r", encoding="utf-8") as f:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ PATCHER_SNIPPET_MAX_LINES=800 python main.py
 python3 main.py <-h|--help>
 ```
 
+By default the pipeline auto-loads a dummy Finder output if one exists at `Projects/Finder_Output/<project_name>.json`, so you don't pay the IRIS analysis cost every run. If no dummy exists for the selected project, Finder runs end-to-end and produces fresh findings. To force a real Finder run even when a dummy is present, pass `--finder-reanalyze` (this also skips re-extracting the source tree, so it's the right flag when the project is already laid out under `Projects/Sources/`).
+
 ## Commands supported
 The following are some commands you can use when running the AutoSec Pipeline
 ```bash
@@ -154,18 +156,19 @@ python3 main.py --project <project_enum> # ex. WHITESOURCE_CUREKIT_CVE_2022_2308
 # Finder only:
 python3 main.py --mode finder
 
-# Finder only with reanalysis:
+# Finder only with reanalysis (ignore the cached dummy, force a real run):
 python3 main.py --mode finder --finder-reanalyze
 
-# Exploiter only with dummy Finder output:
-python3 main.py --mode exploiter --use-dummy finder
+# Exploiter only (the default finder dummy is loaded automatically):
+python3 main.py --mode exploiter
 
-# Patcher only:
-python3 main.py --mode patcher --use-dummy finder exploiter
+# Patcher only (adds exploiter on top of the default finder dummy):
+python3 main.py --mode patcher --use-dummy exploiter
 
-# Verifier only:
+# Verifier only (adds patcher on top of the default finder dummy):
 python3 main.py --mode verifier --use-dummy patcher
 ```
+- `--use-dummy` extends the default `[finder]` set instead of replacing it, so `--use-dummy patcher` gives you `[finder, patcher]`. Pass multiple values to stack them, e.g. `--use-dummy exploiter patcher`.
 - For a full list use the `python3 main.py <-h|--help>` command
 
 ## Injecting Project Variants CSV
@@ -193,7 +196,7 @@ python Pipeline/scripts/convert_to_finder_output.py <project_name> <cwe_id> <jso
 # example: 
 # python Pipeline/scripts/convert_to_finder_output.py perwendel__spark_CVE-2018-9159_2.7.1 cwe-022 finder_output_perwendel.json
 ```
-3. This will create a `json` file in `Projects/Finder_Output`
+3. This will create a `json` file in `Projects/Finder_Output`. Once the file is in place, subsequent runs of the same project will auto-load it as the Finder dummy and skip the IRIS analysis -> Finder stage short-circuits, pipeline starts from Exploiter.
 
 ## Project Structure
 - Only files relevant to the primary AutoSec Pipeline have been listed

--- a/README.md
+++ b/README.md
@@ -201,11 +201,14 @@ python Pipeline/scripts/generate_project_variants.py AutoSec_120_Project_Variant
 2. After finder analysis run the following command from the project root:
 ```bash
 python Pipeline/scripts/convert_to_finder_output.py <project_name> <cwe_id> <output_json>
+# `.json` extension is optional — appended automatically if omitted
 
 # example (auto-load-enabled name — matches ProjectVariants.dummy_finder_output):
 python Pipeline/scripts/convert_to_finder_output.py perwendel__spark_CVE-2018-9159_2.7.1 cwe-022 PERWENDEL_SPARK_CVE_2018_9159.json
+# equivalent, without the extension:
+python Pipeline/scripts/convert_to_finder_output.py perwendel__spark_CVE-2018-9159_2.7.1 cwe-022 PERWENDEL_SPARK_CVE_2018_9159
 ```
-3. This writes the JSON to `Projects/Finder_Output/<output_json>` verbatim. For subsequent runs to auto-load it as the Finder dummy (and short-circuit IRIS so the pipeline starts from Exploiter), the `<output_json>` filename **must** match the selected project's `ProjectVariants.dummy_finder_output` path — that's `<PROJECT_ENUM>.json` (e.g. `PERWENDEL_SPARK_CVE_2018_9159.json`). Arbitrary names like `finder_output_perwendel.json` will be saved but never picked up.
+3. This writes the JSON to `Projects/Finder_Output/<output_json>` (with `.json` appended if you didn't include it). For subsequent runs to auto-load it as the Finder dummy (and short-circuit IRIS so the pipeline starts from Exploiter), the `<output_json>` filename **must** match the selected project's `ProjectVariants.dummy_finder_output` path — that's `<PROJECT_ENUM>.json` (e.g. `PERWENDEL_SPARK_CVE_2018_9159.json`). Arbitrary names like `finder_output_perwendel.json` will be saved but never picked up.
 
 ## Project Structure
 - Only files relevant to the primary AutoSec Pipeline have been listed

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ PATCHER_SNIPPET_MAX_LINES=800 python main.py
 python3 main.py <-h|--help>
 ```
 
-By default the pipeline auto-loads a dummy Finder output if one exists at `Projects/Finder_Output/<project_name>.json`, so you don't pay the IRIS analysis cost every run. If no dummy exists for the selected project, Finder runs end-to-end and produces fresh findings. To force a real Finder run even when a dummy is present, pass `--finder-reanalyze` (this also skips re-extracting the source tree, so it's the right flag when the project is already laid out under `Projects/Sources/`).
+By default the pipeline auto-loads a dummy Finder output if one exists at the path declared by the selected project's `ProjectVariants` entry — `dummy_finder_output`, which is `Projects/Finder_Output/<PROJECT_ENUM>.json` (e.g. `Projects/Finder_Output/WHITESOURCE_CUREKIT_CVE_2022_23082.json`). The filename must match that exact enum-cased path; arbitrary names in `Projects/Finder_Output/` are not auto-loaded. If no dummy exists for the selected project, Finder runs end-to-end and produces fresh findings. To force a real Finder run even when a dummy is present, pass `--finder-reanalyze`; this also reuses the existing source tree under `Projects/Sources/<project_name>/` to skip re-extraction, falling back to re-extracting from the zip if the tree isn't on disk.
 
 ## Commands supported
 The following are some commands you can use when running the AutoSec Pipeline
@@ -163,7 +163,12 @@ python3 main.py --mode finder
 # Finder only with reanalysis (ignore the cached dummy, force a real run):
 python3 main.py --mode finder --finder-reanalyze
 
-# Exploiter only (the default finder dummy is loaded automatically):
+# Exploiter only — requires a pre-existing dummy/cached Finder output for the
+# selected project at the path declared by ProjectVariants.dummy_finder_output
+# (i.e. Projects/Finder_Output/<PROJECT_ENUM>.json). In --mode exploiter the
+# workflow starts at the exploiter node, so Finder never runs to produce one;
+# if the file is missing, finder_output is None and exploiter short-circuits
+# as "no actionable vulnerabilities".
 python3 main.py --mode exploiter
 
 # Patcher only (adds exploiter on top of the default finder dummy):
@@ -195,12 +200,12 @@ python Pipeline/scripts/generate_project_variants.py AutoSec_120_Project_Variant
 1. Run analysis on the desired project, the `Finder` agent will have generated a `.sarif` file of results
 2. After finder analysis run the following command from the project root:
 ```bash
-python Pipeline/scripts/convert_to_finder_output.py <project_name> <cwe_id> <json_name>.json
+python Pipeline/scripts/convert_to_finder_output.py <project_name> <cwe_id> <output_json>
 
-# example: 
-# python Pipeline/scripts/convert_to_finder_output.py perwendel__spark_CVE-2018-9159_2.7.1 cwe-022 finder_output_perwendel.json
+# example (auto-load-enabled name — matches ProjectVariants.dummy_finder_output):
+python Pipeline/scripts/convert_to_finder_output.py perwendel__spark_CVE-2018-9159_2.7.1 cwe-022 PERWENDEL_SPARK_CVE_2018_9159.json
 ```
-3. This will create a `json` file in `Projects/Finder_Output`. Once the file is in place, subsequent runs of the same project will auto-load it as the Finder dummy and skip the IRIS analysis -> Finder stage short-circuits, pipeline starts from Exploiter.
+3. This writes the JSON to `Projects/Finder_Output/<output_json>` verbatim. For subsequent runs to auto-load it as the Finder dummy (and short-circuit IRIS so the pipeline starts from Exploiter), the `<output_json>` filename **must** match the selected project's `ProjectVariants.dummy_finder_output` path — that's `<PROJECT_ENUM>.json` (e.g. `PERWENDEL_SPARK_CVE_2018_9159.json`). Arbitrary names like `finder_output_perwendel.json` will be saved but never picked up.
 
 ## Project Structure
 - Only files relevant to the primary AutoSec Pipeline have been listed


### PR DESCRIPTION
…er_reanalyze semantics

Found the issue I kept hitting: every time I ran the pipeline, the finder node was getting skipped. Turned out it wasn't really a bug — pipeline_main was unconditionally pre-loading a dummy FinderOutput from Projects/Finder_Output/<project>.json into the initial state, so by the time _finder_node ran, the cache check at the top would short-circuit and never invoke IRIS. Working as intended, just bad wiring: you had to comment out a line every time you wanted a real Finder run, and there was no way to say "use cache if it exists, otherwise actually run."

Changes:

load_dummy_finder_output (Pipeline/utils.py) now returns Optional[FinderOutput]. If the JSON doesn't exist it returns None instead of raising FileNotFoundError, so the cache-check short-circuit fails and Finder runs. New projects that don't have a dummy on disk no longer crash at startup.

--use-dummy CLI flag now uses action="extend" with default=["finder"], so the finder dummy is loaded by default and additional dummies stack instead of replacing. --use-dummy patcher now means "finder + patcher" rather than "patcher only," which is what users actually want.

Cleaned up finder_reanalyze in _finder_node. It used to gate two unrelated things at once (source re-extraction AND IRIS cache reuse), and the default mode on subsequent runs ended up as "re-extract source but reuse stale IRIS findings," which didn't make sense to me. Now --overwrite is always passed to IRIS, and finder_reanalyze only controls whether to re-extract source from the zip. The default is "extract + force IRIS recompute"; --finder-reanalyze is "keep existing source + force IRIS recompute," used by the Exploiter retry path where the source is already on disk.

--finder-reanalyze now also bypasses the dummy cache short-circuit at the top of _finder_node, so it serves as the manual escape hatch for "ignore the cached dummy, force a real Finder run."

Help text on --finder-reanalyze updated to reflect the new semantics (the old text said "Force Finder reanalysis using --overwrite," which was misleading once --overwrite became always-on).

Added a fallback in _finder_node: if finder_reanalyze=True but the project source tree isn't actually on disk (e.g. dummy was used on the first pass, then Exploiter retry triggered a real Finder run), force --zip-path anyway. Otherwise IRIS would blow up trying to Maven-build a non-existent tree. Logs an info line when this fallback fires so it's debuggable. Net effect:

python main.py --project FOO (dummy on disk) -> Finder skipped, pipeline uses cached output python main.py --project FOO (no dummy) -> Finder runs end-to-end, no crash python main.py --project FOO --finder-reanalyze -> dummy ignored, Finder runs and reuses existing source tree python main.py --project FOO --use-dummy patcher -> finder + patcher dummies both loaded Exploiter retry after a dummy first pass -> Finder re-extracts source automatically instead of crashing in Maven